### PR TITLE
Added Read/Show for XML file

### DIFF
--- a/src/Net/Beacon.hs
+++ b/src/Net/Beacon.hs
@@ -44,7 +44,6 @@ import Text.XML.Light.Proc
 import Text.XML.Light.Types
 
 import qualified Data.ByteString.Lazy as B
-import Data.ByteString.Char8 (pack, unpack)
 import Network.HTTP.Conduit (simpleHttp)
 import Numeric
 
@@ -85,18 +84,8 @@ data Record =
     --     2 - Time between values is greater than the frequency, but the
     --         chain is still intact
   , statusCode :: Int
+  } deriving (Show, Eq)
 
-    -- | The original XML file.
-  , xmlFile :: B.ByteString
-  } deriving (Eq)
-
-instance Show Record where
-  show = unpack . B.toStrict . xmlFile
-
-instance Read Record where
-  readsPrec n s = case getRecord $ B.fromStrict $ pack s of
-    Nothing -> [(error "Parse error while reading NIST Beacon XML file.","")]
-    (Just r) -> [(r,"")]
 
 type Timestamp = Int
 
@@ -149,7 +138,6 @@ getRecord stuff = do
     <*> (hexToBS <$> fc "signatureValue")
     <*> (hexToBS <$> fc "outputValue")
     <*> (read    <$> fc "statusCode")
-    <*> Just stuff
   where
     findChild' xml name = strContent <$> filterChildName ((name ==) . qName) xml
 

--- a/src/Net/Beacon.hs
+++ b/src/Net/Beacon.hs
@@ -44,6 +44,7 @@ import Text.XML.Light.Proc
 import Text.XML.Light.Types
 
 import qualified Data.ByteString.Lazy as B
+import Data.ByteString.Char8 (pack, unpack)
 import Network.HTTP.Conduit (simpleHttp)
 import Numeric
 
@@ -84,8 +85,18 @@ data Record =
     --     2 - Time between values is greater than the frequency, but the
     --         chain is still intact
   , statusCode :: Int
-  } deriving (Show, Eq)
 
+    -- | The original XML file.
+  , xmlFile :: B.ByteString
+  } deriving (Eq)
+
+instance Show Record where
+  show = unpack . B.toStrict . xmlFile
+
+instance Read Record where
+  readsPrec n s = case getRecord $ B.fromStrict $ pack s of
+    Nothing -> [(error "Parse error while reading NIST Beacon XML file.","")]
+    (Just r) -> [(r,"")]
 
 type Timestamp = Int
 
@@ -138,6 +149,7 @@ getRecord stuff = do
     <*> (hexToBS <$> fc "signatureValue")
     <*> (hexToBS <$> fc "outputValue")
     <*> (read    <$> fc "statusCode")
+    <*> Just stuff
   where
     findChild' xml name = strContent <$> filterChildName ((name ==) . qName) xml
 


### PR DESCRIPTION
I'd really like to be able to store beacon records offline. I added custom `Read`/`Show` instances so that I can `show` the XML file and `read` from an XML file directly.

Disclaimer: I know next to nothing about writing `Read` instances, but the following program prints `True`:

```
import Data.Maybe
import Beacon
main :: IO ()
main = do
  r <- fromJust <$> getLastRecord
  let r' = read (show r)
  print $ r == r'
```

In particular, my `Read` instance ignores the precedence operator, and I'm not quite sure what to do about returning a list of elements. Finally, I wasn't sure if it would be better to put the `error` as the result of the case or inside the list.
